### PR TITLE
Ensure people post type exists before using it

### DIFF
--- a/includes/class-wsuwp-people-directory-theme.php
+++ b/includes/class-wsuwp-people-directory-theme.php
@@ -72,8 +72,10 @@ class WSUWP_People_Directory_Theme {
 	 * @since 0.1.0
 	 */
 	public function rewrite_rules() {
-		add_rewrite_tag( '%wsuwp_person%', '([^/]+)', WSUWP_People_Post_Type::$post_type_slug . '=' );
-		add_permastruct( 'person', '/profile/%wsuwp_person%/', false );
+		if ( class_exists( 'WSUWP_People_Post_Type' ) ) {
+			add_rewrite_tag( '%wsuwp_person%', '([^/]+)', WSUWP_People_Post_Type::$post_type_slug . '=' );
+			add_permastruct( 'person', '/profile/%wsuwp_person%/', false );
+		}
 	}
 
 	/**


### PR DESCRIPTION
If the theme is activated and the plugin is not for any reason, then a fatal error is shown. This checks to make sure the class is available before doing anything with rewrite rules.