### PR TITLE
[PR] Profile access for Profile Owners

### DIFF
--- a/includes/class-wsuwp-people-directory-roles.php
+++ b/includes/class-wsuwp-people-directory-roles.php
@@ -266,10 +266,8 @@ class WSUWP_People_Directory_Roles {
 			return;
 		}
 
-		$screen = get_current_screen();
-
 		// Show users with either custom role only their media.
-		if ( 'upload' === $screen->id || ( isset( $_REQUEST['action'] ) && 'query-attachments' === $_REQUEST['action'] ) ) { //@codingStandardsIgnoreLine
+		if ( 'attachment' === $query->query['post_type'] ) {
 			$query->set( 'author', $user->ID );
 		}
 
@@ -278,7 +276,7 @@ class WSUWP_People_Directory_Roles {
 		}
 
 		// Show Unit Admins only the people posts they share University Organizations with.
-		if ( 'edit-wsuwp_people_profile' === $screen->id ) {
+		if ( 'wsuwp_people_profile' === $query->query['post_type'] ) {
 			$terms_args = array(
 				'fields' => 'ids',
 			);


### PR DESCRIPTION
Fixes #14.

This is pretty goofy, but it will at least make the Profile Owners role usable if we need to start using it soon. Preferably, we wouldn't have two menu items that are so similar (that is, the people directory profile and the user profile), so hopefully we can think of something better before the Profile owner role is widely used.

The first commit here is good, though, I think :)